### PR TITLE
スキルの取得数に応じて、スキルの位置を変更(使用してスキルの座標が変わるのはリストの影響) 他のスキルの演出中はスキルを使えないようにした…

### DIFF
--- a/legend/legend/src/player/player.cpp
+++ b/legend/legend/src/player/player.cpp
@@ -63,7 +63,7 @@ bool Player::Init(actor::IActorMediator* mediator,
   model_ = resource.GetModel().Get(resource_name::model::PLAYER);
 
   //スキルマネージャーの初期化
-  skill_manager_.Init(mediator_);
+  skill_manager_.Init(mediator_, this);
 
   is_hit_obstacle_ = false;
   se_interval_.Init(0.0f);
@@ -79,10 +79,12 @@ bool Player::Update() {
   //スキルのデバック用のGUI
   if (ImGui::Begin("Skill")) {
     if (ImGui::Button("Add Skill")) {
-      std::shared_ptr<skill::SkillPencil> skill =
-          std::make_shared<skill::SkillPencil>();
-      skill->Init(mediator_, this);
-      skill_manager_.AddSkill(skill);
+      if (skill_manager_.GetSkillList().size() < 5) {
+        std::shared_ptr<skill::SkillPencil> skill =
+            std::make_shared<skill::SkillPencil>();
+        skill->Init(mediator_, this);
+        skill_manager_.AddSkill(skill);
+      }
     }
   }
   ImGui::End();

--- a/legend/legend/src/skill/explosion_pencil.cpp
+++ b/legend/legend/src/skill/explosion_pencil.cpp
@@ -41,10 +41,6 @@ void ExplosionPencil::Init(util::Transform transform,
 
   transform_cb_.GetStagingRef().world = transform_.CreateWorldMatrix();
   transform_cb_.UpdateStaging();
-  //モデルの初期化
-  //モデルは適当に入ってる
-  model_ = resource.GetModel().Get(
-      util::resource::resource_names::model::STATIONERY_01);
 }
 
 //更新
@@ -58,13 +54,9 @@ bool ExplosionPencil::Update() {
   float mass = 0.0f;
   sphere_->SetScale(radius_, mass);
   mediator_->AddCollider(sphere_);
+  sphere_->SetFlags(sphere_->GetFlags() |
+      btCollisionObject::CF_NO_CONTACT_RESPONSE);
   return true;
-}
-
-//描画
-void ExplosionPencil::Draw() {
-  if (is_destroy_) return;
-  actor::Actor::Draw();
 }
 
 //衝突判定

--- a/legend/legend/src/skill/explosion_pencil.h
+++ b/legend/legend/src/skill/explosion_pencil.h
@@ -29,10 +29,6 @@ class ExplosionPencil : public actor::Actor {
    */
   bool Update();
   /**
-   * @brief •`‰æ
-   */
-  void Draw() override;
-  /**
    * @brief Õ“Ë”»’è
    */
   void OnHit(bullet::Collider* other);

--- a/legend/legend/src/skill/skill.cpp
+++ b/legend/legend/src/skill/skill.cpp
@@ -22,6 +22,11 @@ void Skill::RemaingRecastTurnUpdate() {
   //カウントを更新
   remaining_recast_turn_--;
 }
+void Skill::AdjustPosition(math::Vector3 adjust_position) {
+  transform_.SetPosition(player_->GetPosition() + adjust_position);
+  transform_.SetRotation(player_->GetRotation());
+  box_->SetTransform(transform_);
+}
 // i32 Skill::GetModelID() { return model_id_; }
 
 i32 Skill::GetRemainingUsableCount() { return remaining_usable_count_; }

--- a/legend/legend/src/skill/skill.h
+++ b/legend/legend/src/skill/skill.h
@@ -57,6 +57,8 @@ class Skill : public actor::Actor {
    */
   void RemaingRecastTurnUpdate();
 
+  void AdjustPosition(math::Vector3 adjust_position);
+
   // i32 GetModelID();
   i32 GetRemainingUsableCount();
   i32 GetRemainingRecastTurn();

--- a/legend/legend/src/skill/skill_manager.cpp
+++ b/legend/legend/src/skill/skill_manager.cpp
@@ -14,16 +14,17 @@ SkillManager::SkillManager() {}
 SkillManager::~SkillManager() {}
 
 //初期化
-void SkillManager::Init(actor::IActorMediator* mediator) {
+void SkillManager::Init(actor::IActorMediator* mediator, player::Player* player) {
   this->mediator_ = mediator;
+  player_ = player;
   select_ui_.Init();
   select_move_ = false;
 }
 
 //スキル取得時
-void SkillManager::GetSkill(i32 skill_id, player::Player* player) {
+void SkillManager::GetSkill(i32 skill_id) {
   std::shared_ptr<SkillPencil> skill;
-  skill->Init(mediator_, player);
+  skill->Init(mediator_, player_);
   this_turn_get_skills_.push_back(skill);
 }
 
@@ -37,8 +38,28 @@ void SkillManager::AddSkill(std::shared_ptr<Skill> skill) {
 
 //更新
 void SkillManager::Update() {
-  for (auto&& skill : skills_) {
-    skill->Update();
+  // for (auto&& skill : skills_) {
+  //  skill->Update();
+  //}
+
+  for (i32 i = 0; i < skills_.size(); i++) {
+    skills_[i]->Update();
+
+    if (skills_[i]->GetUseFlag()) continue;
+    math::Vector3 pos;
+    if (i == 0)
+      pos = math::Vector3::kUpVector;
+    else if (i == 1)
+      pos = math::Vector3::kRightVector * 1.5f;
+    else if (i == 2)
+      pos = math::Vector3::kLeftVector * 1.5f;
+    else if (i == 3)
+      pos = math::Vector3::kUpVector + math::Vector3::kRightVector;
+    else
+      pos = math::Vector3::kUpVector + math::Vector3::kLeftVector;
+    pos = math::Matrix4x4::MultiplyCoord(
+        pos, player_->GetTransform().GetRotation().ToMatrix());
+    skills_[i]->AdjustPosition(pos);
   }
 }
 
@@ -157,7 +178,15 @@ bool SkillManager::SelectSkill() {
 
 //スキルの使用
 void SkillManager::UseSkill() {
-  if (!select_ui_.GetIsSelectMode()) return;
+  bool can_use = true;
+  for (auto&& skill : skills_) {
+    //他のスキルの演出中は使えないようにする
+    if (skill->ProductionFlag()) {
+      can_use = false;
+      break;
+    }
+  }
+  if (!select_ui_.GetIsSelectMode() || !can_use) return;
 
   auto& input = game::GameDevice::GetInstance()->GetInput();
   auto& audio = game::GameDevice::GetInstance()->GetAudioManager();

--- a/legend/legend/src/skill/skill_manager.h
+++ b/legend/legend/src/skill/skill_manager.h
@@ -21,11 +21,11 @@ class SkillManager {
   /**
    * @brief 初期化処理
    */
-  void Init(actor::IActorMediator *mediator);
+  void Init(actor::IActorMediator *mediator, player::Player* player);
   /**
    * @brief スキルを拾った際のメソッド
    */
-  void GetSkill(i32 skill_id, player::Player *player);
+  void GetSkill(i32 skill_id);
   /**
    * @brief スキルの獲得処理
    */
@@ -84,6 +84,8 @@ class SkillManager {
 
   //! 入力判定
   bool select_move_;
+  //! プレイヤー
+  player::Player* player_;
 };
 }  // namespace skill
 }  // namespace legend

--- a/legend/legend/src/skill/skill_pencil.cpp
+++ b/legend/legend/src/skill/skill_pencil.cpp
@@ -91,9 +91,9 @@ bool SkillPencil::Update() {
     return true;
   }
 
-  transform_.SetPosition(player_->GetPosition() + math::Vector3::kUpVector);
-  transform_.SetRotation(player_->GetRotation());
-  box_->SetTransform(this->transform_);
+  //transform_.SetPosition(player_->GetPosition() + math::Vector3::kUpVector);
+  //transform_.SetRotation(player_->GetRotation());
+  //box_->SetTransform(this->transform_);
 
   return true;
 }


### PR DESCRIPTION
… プレイヤーが鉛筆スキルの影響を受けないようになった(?)