### PR TITLE
消しゴムは無視

### DIFF
--- a/legend/legend/src/search/search_manager.cpp
+++ b/legend/legend/src/search/search_manager.cpp
@@ -5,6 +5,7 @@
 
 #include "src/game/game_device.h"
 #include "src/skill/skill_item_box.h"
+#include "src/object/fragment.h"
 
 namespace legend {
 namespace search {
@@ -280,6 +281,11 @@ bool SearchManager::OnCollision(math::Vector3 start, math::Vector3 end) {
         dynamic_cast<skill::Skill*>(act->GetOwner());
     if (sb) {
       continue;
+    }
+    object::Fragment* fragment =
+        dynamic_cast<object::Fragment*>(act->GetOwner());
+    if (fragment) {
+        continue;
     }
       return true;
   }

--- a/legend/legend/src/system/turn_system.cpp
+++ b/legend/legend/src/system/turn_system.cpp
@@ -650,7 +650,7 @@ system::GameDataStorage::GameData legend::system::TurnSystem::GetResult()
   }();
   //プレイヤーが死亡したか、敵のボスが死亡したらその情報を返す
   return system::GameDataStorage::GameData{
-      end_type, CalcPlayerStrengthToPrintNumber(*player_), current_turn_};
+      end_type, CalcPlayerStrengthToPrintNumber(*player_), current_turn_ + 1};
 }
 
 bool legend::system::TurnSystem::GenerateActors() {  //ステージデータの読み込み


### PR DESCRIPTION
リザルトのターン表記を+1