### PR TITLE
糊スキルの実装 ポインタでなかった部分をポインタに変更 ターン終了時にもスキルの更新が行われるようにした GUIでのスキル追加処理を変更

### DIFF
--- a/legend/legend/legend.vcxproj
+++ b/legend/legend/legend.vcxproj
@@ -177,6 +177,8 @@
     <ClCompile Include="src\skill\skill.cpp" />
     <ClCompile Include="src\skill\skill_item_box.cpp" />
     <ClCompile Include="src\skill\skill_manager.cpp" />
+    <ClCompile Include="src\skill\skill_paste.cpp" />
+    <ClCompile Include="src\skill\skill_paste_stick.cpp" />
     <ClCompile Include="src\skill\skill_pencil.cpp" />
     <ClCompile Include="src\skill\skill_select_ui.cpp" />
     <ClCompile Include="src\stage_generate\stage_generator.cpp" />
@@ -348,6 +350,8 @@
     <ClInclude Include="src\skill\skill.h" />
     <ClInclude Include="src\skill\skill_item_box.h" />
     <ClInclude Include="src\skill\skill_manager.h" />
+    <ClInclude Include="src\skill\skill_paste.h" />
+    <ClInclude Include="src\skill\skill_paste_stick.h" />
     <ClInclude Include="src\skill\skill_pencil.h" />
     <ClInclude Include="src\skill\skill_select_ui.h" />
     <ClInclude Include="src\skill\skill_type.h" />

--- a/legend/legend/legend.vcxproj.filters
+++ b/legend/legend/legend.vcxproj.filters
@@ -131,6 +131,8 @@
     <ClCompile Include="src\scenes\fade_in_out.cpp" />
     <ClCompile Include="src\actor\actor_render_command_list.cpp" />
     <ClCompile Include="src\scenes\result_scene.cpp" />
+    <ClCompile Include="src\skill\skill_paste_stick.cpp" />
+    <ClCompile Include="src\skill\skill_paste.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\stdafx.h" />
@@ -310,6 +312,8 @@
     <ClInclude Include="src\bullet\shape_type.h" />
     <ClInclude Include="src\actor\actor_render_command_list.h" />
     <ClInclude Include="src\scenes\result_scene.h" />
+    <ClInclude Include="src\skill\skill_paste_stick.h" />
+    <ClInclude Include="src\skill\skill_paste.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="src\.clang-format" />

--- a/legend/legend/src/enemy/boss.cpp
+++ b/legend/legend/src/enemy/boss.cpp
@@ -183,6 +183,15 @@ void Boss::OnHit(bullet::Collider* other) {
       e->GetCollider()->ApplyCentralImpulse(direction * power_);
     }
   }
+  //å–Ç…êGÇÍÇΩ
+  {
+    skill::SkillPaste* paste =
+        dynamic_cast<skill::SkillPaste*>(other->GetOwner());
+    if (paste) {
+      //åªèÛÅAé~Ç‹ÇÈÇÊÇ§Ç…
+      GetCollider()->ApplyCentralImpulse(-0.1f * GetVelocity());
+    }
+  }
 }
 
 }  // namespace enemy

--- a/legend/legend/src/enemy/enemy.cpp
+++ b/legend/legend/src/enemy/enemy.cpp
@@ -197,6 +197,15 @@ void Enemy::OnHit(bullet::Collider* other) {
         p->GetCollider()->ApplyCentralImpulse(direction * power_);
       }
     }
+    //å–Ç…êGÇÍÇΩ
+    {
+      skill::SkillPaste* paste =
+          dynamic_cast<skill::SkillPaste*>(other->GetOwner());
+      if (paste) {
+        //åªèÛÅAé~Ç‹ÇÈÇÊÇ§Ç…
+        GetCollider()->ApplyCentralImpulse(-0.1f * GetVelocity());
+      }
+    }
   }
   //É{ÉXÇ…êGÇÍÇΩ
   {

--- a/legend/legend/src/player/player.cpp
+++ b/legend/legend/src/player/player.cpp
@@ -78,10 +78,18 @@ bool Player::Update() {
 
   //スキルのデバック用のGUI
   if (ImGui::Begin("Skill")) {
-    if (ImGui::Button("Add Skill")) {
+    if (ImGui::Button("Add SkillPencil")) {
       if (skill_manager_.GetSkillList().size() < 5) {
         std::shared_ptr<skill::SkillPencil> skill =
             std::make_shared<skill::SkillPencil>();
+        skill->Init(mediator_, this);
+        skill_manager_.AddSkill(skill);
+      }
+    }
+    if (ImGui::Button("Add SkillPasteStick")) {
+      if (skill_manager_.GetSkillList().size() < 5) {
+        std::shared_ptr<skill::SkillPasteStick> skill =
+            std::make_shared<skill::SkillPasteStick>();
         skill->Init(mediator_, this);
         skill_manager_.AddSkill(skill);
       }
@@ -96,7 +104,7 @@ bool Player::Update() {
   //  box_->ApplyCentralImpulse(input_velocity_ * power_);
   //}
 
-  //if (skill_manager_.IsProductionNow()) {
+  // if (skill_manager_.IsProductionNow()) {
   //  return true;
   //}
 
@@ -376,7 +384,24 @@ void Player::OnHit(bullet::Collider* other) {
 
 void Player::SkillUpdate() {
   //スキルマネージャーの更新
-  skill_manager_.SelectUpdate();
+  skill_manager_.UseSkill();
+  skill_manager_.EndSkill();
+  skill_manager_.RemoveSkill();
+}
+
+//ターン終了時の処理
+bool Player::SkillUpdateTurnEnd() {
+  if (mediator_->GetCurrentTurn() == system::Mode::PLAYER_SKILL_AFTER_MOVED) {
+    skill_manager_.PlayerTurnEnd();
+    skill_manager_.EndSkill();
+    skill_manager_.RemoveSkill();
+  } else if (mediator_->GetCurrentTurn() == system::Mode::ENEMY_MOVE_END) {
+    skill_manager_.EnemyTurnEnd();
+    skill_manager_.EndSkill();
+    skill_manager_.RemoveSkill();
+  }
+
+  return skill_manager_.IsProductionNow();
 }
 
 }  // namespace player

--- a/legend/legend/src/player/player.h
+++ b/legend/legend/src/player/player.h
@@ -135,8 +135,14 @@ class Player : public actor::Actor {
   void OnHit(bullet::Collider* other);
 
   bullet::Collider* GetCollider() const { return box_.get(); }
-
+  /**
+   * @brief スキルの更新処理
+   */
   void SkillUpdate();
+  /**
+   * @brief ターン終了時のスキルの更新処理
+   */
+  bool SkillUpdateTurnEnd();
 
  private:
   //! 速度

--- a/legend/legend/src/skill/explosion_pencil.cpp
+++ b/legend/legend/src/skill/explosion_pencil.cpp
@@ -35,7 +35,6 @@ void ExplosionPencil::Init(util::Transform transform,
   sphere_->SetFlags(sphere_->GetFlags() |
                     btCollisionObject::CF_NO_CONTACT_RESPONSE);
   mediator->AddCollider(sphere_);
-  is_destroy_ = false;
 
   transform_cb_.GetStagingRef().world = transform_.CreateWorldMatrix();
   transform_cb_.UpdateStaging();
@@ -53,7 +52,7 @@ bool ExplosionPencil::Update() {
   sphere_->SetScale(radius_, mass);
   mediator_->AddCollider(sphere_);
   sphere_->SetFlags(sphere_->GetFlags() |
-      btCollisionObject::CF_NO_CONTACT_RESPONSE);
+                    btCollisionObject::CF_NO_CONTACT_RESPONSE);
   return true;
 }
 
@@ -91,7 +90,6 @@ void ExplosionPencil::OnHit(bullet::Collider* other) {
 
 //íœ
 void ExplosionPencil::Destroy(actor::IActorMediator* mediator) {
-  is_destroy_ = true;
   mediator->RemoveCollider(sphere_);
   mediator->RemoveActor(this);
 }

--- a/legend/legend/src/skill/explosion_pencil.h
+++ b/legend/legend/src/skill/explosion_pencil.h
@@ -44,8 +44,6 @@ class ExplosionPencil : public actor::Actor {
   float radius_;
   //! ”š”­ˆĞ—Í
   float explosion_power_;
-  //! Á–Å”»’è
-  bool is_destroy_;
 };
 }  // namespace skill
 }  // namespace legend

--- a/legend/legend/src/skill/skill_manager.h
+++ b/legend/legend/src/skill/skill_manager.h
@@ -2,6 +2,7 @@
 #define LEGEND_SKILL_SKILL_MANAGER_H_
 
 #include "src/skill/skill.h"
+#include "src/skill/skill_paste_stick.h"
 #include "src/skill/skill_pencil.h"
 #include "src/skill/skill_select_ui.h"
 #include "src/skill/skill_type.h"
@@ -21,7 +22,7 @@ class SkillManager {
   /**
    * @brief 初期化処理
    */
-  void Init(actor::IActorMediator *mediator, player::Player* player);
+  void Init(actor::IActorMediator* mediator, player::Player* player);
   /**
    * @brief スキルを拾った際のメソッド
    */
@@ -67,16 +68,14 @@ class SkillManager {
    */
   void UseSkill();
   /**
-   * @brief 選択したスキルの更新
-   */
-  void SelectUpdate();
-  /**
    * @brief スキル終了
    */
   void EndSkill();
 
+  void SetPosition(std::shared_ptr<Skill> skill, i32 skill_num);
+
  private:
-  actor::IActorMediator *mediator_;
+  actor::IActorMediator* mediator_;
   //! 所持できる最大スキル数
   i32 skill_max_count_;
   //! 所持しているスキル用リスト
@@ -90,6 +89,8 @@ class SkillManager {
   bool select_move_;
   //! プレイヤー
   player::Player* player_;
+  //! 糊
+  std::vector<SkillPaste*> pastes_;
 };
 }  // namespace skill
 }  // namespace legend

--- a/legend/legend/src/skill/skill_paste.cpp
+++ b/legend/legend/src/skill/skill_paste.cpp
@@ -1,0 +1,59 @@
+#include "src/skill/skill_paste.h"
+
+#include "src/game/game_device.h"
+#include "src/util/resource/resource_names.h"
+
+namespace legend {
+namespace skill {
+namespace resource_name = util::resource::resource_names;
+
+//コンストラクタ
+SkillPaste::SkillPaste() : Parent(L"SkillPaste") {}
+
+//デストラクタ
+SkillPaste::~SkillPaste() {}
+
+//初期化
+void SkillPaste::Init(math::Vector3 position, actor::IActorMediator* mediator) {
+  if (!Parent::Init(mediator)) {
+    return;
+  }
+
+  float y = game::GameDevice::GetInstance()->GetRandom().Range(-180.0f, 180.0f);
+  math::Quaternion rotate =
+      math::Quaternion::FromEular(0, y * math::util::DEG_2_RAD, 0);
+
+  transform_.SetPosition(position);
+  transform_.SetRotation(rotate);
+  transform_.SetScale(math::Vector3::kUnitVector);
+
+  bullet::BoundingBox::InitializeParameter parameter;
+  parameter.position = transform_.GetPosition();
+  parameter.rotation = transform_.GetRotation();
+  parameter.scale = math::Vector3(3.25f, 0.25f, 3.25f);
+  parameter.mass = 0.0f;
+  box_ = std::make_shared<bullet::BoundingBox>(this, parameter);
+  box_->SetFlags(box_->GetFlags() | btCollisionObject::CF_NO_CONTACT_RESPONSE);
+  mediator->AddCollider(box_);
+
+  auto& resource = game::GameDevice::GetInstance()->GetResource();
+
+  transform_cb_.GetStagingRef().world = transform_.CreateWorldMatrix();
+  transform_cb_.UpdateStaging();
+  //モデルの初期化
+  model_ = resource.GetModel().Get(resource_name::model::STATIONERY_02);
+}
+
+//更新
+bool SkillPaste::Update() { return true; }
+
+//描画
+void SkillPaste::Draw() { actor::Actor::Draw(); }
+
+//削除
+void SkillPaste::Destroy(actor::IActorMediator* mediator) {
+  mediator->RemoveCollider(box_);
+  mediator->RemoveActor(this);
+}
+}  // namespace skill
+}  // namespace legend

--- a/legend/legend/src/skill/skill_paste.h
+++ b/legend/legend/src/skill/skill_paste.h
@@ -1,0 +1,45 @@
+#ifndef LEGEND_SKILL_SKILL_PASTE_H_
+#define LEGEND_SKILL_SKILL_PASTE_H_
+
+#include "src/actor/actor.h"
+#include "src/bullet/bounding_box.h"
+
+namespace legend {
+namespace skill {
+class SkillPaste : public actor::Actor {
+  using Parent = actor::Actor;
+
+ public:
+  /**
+   * @brief コンストラクタ
+   */
+  SkillPaste();
+  /**
+   * @brief デストラクタ
+   */
+  virtual ~SkillPaste();
+  /**
+   * @brief 初期化
+   */
+  void Init(math::Vector3 position, actor::IActorMediator* mediator);
+  /**
+   * @brief 更新
+   */
+  bool Update();
+  /**
+   * @brief 描画
+   */
+  void Draw();
+  /**
+   * @brief 削除
+   */
+  void Destroy(actor::IActorMediator* mediator);
+
+ private:
+  //! コライダー
+  std::shared_ptr<bullet::BoundingBox> box_;
+};
+}  // namespace skill
+}  // namespace legend
+
+#endif  //! LEGEND_SKILL_SKILL_PASTE_H_

--- a/legend/legend/src/skill/skill_paste_stick.cpp
+++ b/legend/legend/src/skill/skill_paste_stick.cpp
@@ -1,0 +1,147 @@
+#include "src/skill/skill_paste_stick.h"
+
+#include "src/game/game_device.h"
+#include "src/player/player.h"
+#include "src/util/resource/resource_names.h"
+
+namespace legend {
+namespace skill {
+namespace resource_name = util::resource::resource_names;
+
+//コンストラクタ
+SkillPasteStick::SkillPasteStick() {}
+
+//デストラクタ
+SkillPasteStick::~SkillPasteStick() {}
+
+//初期化
+bool SkillPasteStick::Init(actor::IActorMediator* mediator,
+                           player::Player* player) {
+  if (!Parent::Init(mediator, player)) {
+    return false;
+  }
+  //! 規定使用可能回数
+  usable_count_ = 1;
+  //! 残り使用可能回数
+  remaining_usable_count_ = usable_count_;
+  //! 再使用まで規定のターン数
+  recast_turn_ = 1;
+  //! 残り再使用までのターン数
+  remaining_recast_turn_ = 0;
+  //! スキルの発動タイミング
+  activetion_timing_ = SkillActivationTiming::PLAYER_TURN_END;
+  //! スキルの効果終了タイミング
+  end_timing_ = SkillEffectEndTiming::ENEMY_TURN_END;
+  //! 使用されているかのフラグ
+  is_use_ = false;
+  is_production_ = false;
+  instance_count_ = 6;
+
+  player_ = player;
+
+  transform_.SetPosition(player->GetPosition() + math::Vector3::kUpVector);
+  transform_.SetRotation(player->GetRotation());
+  transform_.SetScale(math::Vector3::kUnitVector);
+  bullet::BoundingBox::InitializeParameter params;
+  params.position = transform_.GetPosition();
+  params.rotation = transform_.GetRotation();
+  params.scale = math::Vector3(0.5f, 0.5f, 5.0f);
+  params.mass = 0.0f;
+
+  box_ = std::make_shared<bullet::BoundingBox>(this, params);
+  box_->SetFlags(box_->GetFlags() | btCollisionObject::CF_NO_CONTACT_RESPONSE);
+  mediator_->AddCollider(box_);
+
+  auto& device = game::GameDevice::GetInstance()->GetDevice();
+  auto& resource = game::GameDevice::GetInstance()->GetResource();
+
+  transform_cb_.GetStagingRef().world = transform_.CreateWorldMatrix();
+  transform_cb_.UpdateStaging();
+  //モデルの初期化
+  model_ = resource.GetModel().Get(resource_name::model::STATIONERY_02);
+
+  //スキルアイコンのテクスチャ設定
+  skill_icon_texture_ =
+      resource.GetTexture().Get(resource_name::texture::UI_SKILL_ICON_2);
+
+  return true;
+}
+
+//更新
+bool SkillPasteStick::Update() {
+  if (player_ == nullptr) {
+    return false;
+  }
+
+  for (auto&& paste : pastes_) {
+    paste->Update();
+  }
+
+  return true;
+}
+
+//描画
+void SkillPasteStick::Draw() {
+  for (auto&& paste : pastes_) {
+    paste->Draw();
+  }
+
+  actor::Actor::Draw();
+}
+
+//使用
+void SkillPasteStick::Use() { is_use_ = true; }
+
+//発動
+void SkillPasteStick::Action() {
+  is_production_ = true;
+  ProductionUpdate();
+  mediator_->PlayerSkillActivate();
+}
+
+//演出の更新
+void SkillPasteStick::ProductionUpdate() {
+  for (i32 i = 0; i < instance_count_; i++) {
+    math::Vector3 position;
+    if (i == 0) {
+      position = (math::Vector3::kRightVector + math::Vector3::kForwardVector)
+                     .Normalized() *
+                 10;
+    } else if (i == 1) {
+      position = math::Vector3::kRightVector.Normalized() * 10;
+    } else if (i == 2) {
+      position = (math::Vector3::kRightVector + math::Vector3::kBackwardVector)
+                     .Normalized() *
+                 10;
+    } else if (i == 3) {
+      position = (math::Vector3::kLeftVector + math::Vector3::kBackwardVector)
+                     .Normalized() *
+                 10;
+    } else if (i == 4) {
+      position = math::Vector3::kLeftVector.Normalized() * 10;
+    } else {
+      position = (math::Vector3::kLeftVector + math::Vector3::kForwardVector)
+                     .Normalized() *
+                 10;
+    }
+
+    position += player_->GetTransform().GetPosition();
+    position.y = 1.0f;
+    std::shared_ptr<SkillPaste> paste = std::make_shared<SkillPaste>();
+    paste->Init(position, mediator_);
+    pastes_.emplace_back(std::move(paste));
+  }
+  mediator_->PlayerSkillDeactivate();
+  is_production_ = false;
+}
+
+//終了
+void SkillPasteStick::EndAction() {
+  remaining_usable_count_--;
+  for (auto&& paste : pastes_) {
+    paste->Destroy(mediator_);
+  }
+  if (remaining_usable_count_ <= 0) mediator_->RemoveActor(this);
+}
+}  // namespace skill
+}  // namespace legend

--- a/legend/legend/src/skill/skill_paste_stick.h
+++ b/legend/legend/src/skill/skill_paste_stick.h
@@ -1,26 +1,23 @@
-#ifndef LEGEND_SKILL_SKILL_PENCIL_H_
-#define LEGEND_SKILL_SKILL_PENCIL_H_
+#ifndef LEGEND_SKILL_SKILL_PASTE_STICK_H_
+#define LEGEND_SKILL_SKILL_PASTE_STICK_H_
 
-#include "src/bullet/bounding_sphere.h"
-#include "src/skill/explosion_pencil.h"
 #include "src/skill/skill.h"
-#include "src/util/timer.h"
+#include "src/skill/skill_paste.h"
 
 namespace legend {
 namespace skill {
-
-class SkillPencil : public Skill {
+class SkillPasteStick : public Skill {
   using Parent = Skill;
 
  public:
   /**
    * @brief コンストラクタ
    */
-  SkillPencil();
+  SkillPasteStick();
   /**
    * @brief デストラクタ
    */
-  ~SkillPencil();
+  virtual ~SkillPasteStick();
   /**
    * @brief 初期化
    */
@@ -49,28 +46,14 @@ class SkillPencil : public Skill {
    * @brief 終了
    */
   void EndAction() override;
-  /**
-   * @brief 衝突判定
-   */
-  void OnHit(bullet::Collider* other);
-  /**
-   * @brief 爆発開始
-   */
-  void Explosion();
-  /**
-   * @brief 爆発更新
-   */
-  void ExplosionUpdate();
 
  private:
-  //! タイマー
-  util::CountDownTimer explosion_timer_;
-  //! 爆発クラス
-  std::shared_ptr<ExplosionPencil> explosion_pencil_;
-  //! 爆発中か
-  bool is_explosion_;
+  //! 糊
+  std::vector<std::shared_ptr<SkillPaste>> pastes_;
+  //! 生成数
+  i32 instance_count_;
 };
-
 }  // namespace skill
 }  // namespace legend
-#endif  //! LEGEND_SKILL_SKILL_PENCIL_H_
+
+#endif  //! LEGEND_SKILL_SKILL_PASTE_STICK_H_

--- a/legend/legend/src/skill/skill_pencil.cpp
+++ b/legend/legend/src/skill/skill_pencil.cpp
@@ -91,17 +91,12 @@ bool SkillPencil::Update() {
     return true;
   }
 
-  //transform_.SetPosition(player_->GetPosition() + math::Vector3::kUpVector);
-  //transform_.SetRotation(player_->GetRotation());
-  //box_->SetTransform(this->transform_);
-
   return true;
 }
 
 //描画
 void SkillPencil::Draw() {
-  if (!is_explosion_)
-    actor::Actor::Draw();
+  if (!is_explosion_) actor::Actor::Draw();
 }
 
 //スキルの使用
@@ -113,7 +108,10 @@ void SkillPencil::Use() {
 }
 
 //発動
-void SkillPencil::Action() { is_production_ = true; }
+void SkillPencil::Action() {
+  is_production_ = true;
+  mediator_->PlayerSkillActivate();
+}
 
 //演出の更新
 void SkillPencil::ProductionUpdate() {
@@ -140,7 +138,8 @@ void SkillPencil::ProductionUpdate() {
 void SkillPencil::EndAction() {
   remaining_usable_count_--;
   is_production_ = false;
-  if (is_explosion_) explosion_pencil_.Destroy(mediator_);
+  mediator_->PlayerSkillDeactivate();
+  if (is_explosion_) explosion_pencil_->Destroy(mediator_);
   if (remaining_usable_count_ <= 0) mediator_->RemoveActor(this);
 }
 
@@ -168,7 +167,8 @@ void SkillPencil::Explosion() {
   is_explosion_ = true;
   audio.Start(resource_name::audio::SKILL_PENCIL_HIT, 1.0f);
 
-  explosion_pencil_.Init(transform_, mediator_);
+  explosion_pencil_ = std::make_shared<ExplosionPencil>();
+  explosion_pencil_->Init(transform_, mediator_);
 
   //パーティクルの再生?
 }
@@ -176,7 +176,7 @@ void SkillPencil::Explosion() {
 //爆発更新
 void SkillPencil::ExplosionUpdate() {
   //爆発中は更新
-  if (!explosion_timer_.Update()) explosion_pencil_.Update();
+  if (!explosion_timer_.Update()) explosion_pencil_->Update();
 }
 
 }  // namespace skill

--- a/legend/legend/src/system/turn_system.cpp
+++ b/legend/legend/src/system/turn_system.cpp
@@ -391,6 +391,10 @@ bool TurnSystem::WaitEnemyMoveStart() {
 }
 
 bool TurnSystem::PlayerSkillAfterMoved() {
+  if (player_->SkillUpdateTurnEnd()) {
+    return true;
+  }
+
   auto& audio = game::GameDevice::GetInstance()->GetAudioManager();
   audio.Start(util::resource::resource_names::audio::PLAYER_TURN_END, 1.0f);
 
@@ -412,6 +416,10 @@ bool TurnSystem::EnemyMove() {
 
 //“G‚ÌˆÚ“®I—¹Žžˆ—
 bool TurnSystem::EnemyMoveEnd() {
+  if (player_->SkillUpdateTurnEnd()) {
+    return true;
+  }
+
   AddCurrentTurn();
 
   if (!GenerateActors()) {


### PR DESCRIPTION
削除はうまくできなかったので後回し