### PR TITLE
プレイヤーと敵の衝突時にヒットストップがかかるように

### DIFF
--- a/legend/legend/src/player/player.cpp
+++ b/legend/legend/src/player/player.cpp
@@ -378,6 +378,7 @@ void Player::OnHit(bullet::Collider* other) {
             file = resource_name::audio::PLAYER_ENEMY_HIT_SMALL;
           } else {
             file = resource_name::audio::PLAYER_ENEMY_HIT_BIG;
+            mediator_->SetStopTime(0.25f);
           }
           audio.Start(file, 1.0f);
         }

--- a/legend/legend/src/system/turn_system.cpp
+++ b/legend/legend/src/system/turn_system.cpp
@@ -165,6 +165,16 @@ bool TurnSystem::Init(const std::string& stage_name) {
 }
 
 bool TurnSystem::Update() {
+  if (ImGui::Begin("TurnSystem")) {
+    ImGui::Text("CurrntTurn : %d", current_turn_);
+    if (ImGui::Button("AddTurn")) {
+      //AddCurrentTurn();
+      current_mode_ = Mode::ENEMY_MOVE_END;
+    }
+  }
+
+  ImGui::End();
+
   actor_manager_.Update();
 
   UpdateCamera();
@@ -316,12 +326,12 @@ bool TurnSystem::WaitEnemyMoveStart() {
 }
 
 bool TurnSystem::PlayerSkillAfterMoved() {
-   if (actor_manager_.GetPlayer()->SkillUpdateTurnEnd()) {
+  if (actor_manager_.GetPlayer()->SkillUpdateTurnEnd()) {
     return true;
   }
 
-   auto& audio = game::GameDevice::GetInstance()->GetAudioManager();
-   audio.Start(util::resource::resource_names::audio::PLAYER_TURN_END, 1.0f);
+  auto& audio = game::GameDevice::GetInstance()->GetAudioManager();
+  audio.Start(util::resource::resource_names::audio::PLAYER_TURN_END, 1.0f);
 
   current_mode_ = Mode::ENEMY_MOVING;
   return true;
@@ -339,18 +349,18 @@ bool TurnSystem::EnemyMove() {
 
 //“G‚ÌˆÚ“®I—¹ˆ—
 bool TurnSystem::EnemyMoveEnd() {
-   if (actor_manager_.GetPlayer()->SkillUpdateTurnEnd()) {
+  if (actor_manager_.GetPlayer()->SkillUpdateTurnEnd()) {
     return true;
   }
 
-   AddCurrentTurn();
+  AddCurrentTurn();
 
-   if (!actor_manager_.GenerateActors(current_turn_)) {
+  if (!actor_manager_.GenerateActors(current_turn_)) {
     return false;
   }
 
-   auto& audio = game::GameDevice::GetInstance()->GetAudioManager();
-   audio.Start(audio_name::ENEMY_TURN_END, 1.0f);
+  auto& audio = game::GameDevice::GetInstance()->GetAudioManager();
+  audio.Start(audio_name::ENEMY_TURN_END, 1.0f);
 
   current_mode_ = Mode::PLAYER_MOVE_READY;
   return true;
@@ -522,10 +532,7 @@ void TurnSystem::SetCameraMode(camera_mode::Enum mode) {
 camera::LookAtTargetCamera* TurnSystem::GetPlayerFollowLookatCamera() {
   return player_follow_lookat_camera_;
 }
-Mode TurnSystem::GetCurrentMode()
-{
-    return current_mode_;
-}
+Mode TurnSystem::GetCurrentMode() { return current_mode_; }
 //ƒ^[ƒ“”‚Ì‘‰Á
 void TurnSystem::AddCurrentTurn() { current_turn_++; }
 


### PR DESCRIPTION
ターンを次へ進めるボタンを追加